### PR TITLE
FIX: menu popup under mouse pointer

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,6 +38,6 @@ $(function() {
   var menu = new Menu(/* pass cut, copy, paste labels if you need i18n*/);
   $(document).on("contextmenu", function(e) {
     e.preventDefault();
-    menu.popup(e.originalEvent.x, e.originalEvent.y);
+    menu.popup(e.originalEvent.screenX, e.originalEvent.screenY);
   });
 });


### PR DESCRIPTION
`e.originalEvent.x` and `e.originalEvent.y` contains coordinates relative to the current window,
but `menu.popup(x, y)` uses full screen coordinates.

I've tested this only on windows, I'll report my tests on linux as soon as possible.

node-webkit v0.10.0
